### PR TITLE
Example of using sphinx-jsonschema to generate docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -26,7 +27,9 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinx-jsonschema'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/generic_metadata.rst
+++ b/docs/generic_metadata.rst
@@ -20,3 +20,4 @@ Generic Metadata
    metadata_copyright
    metadata_promotion
    metadata_snapshot
+   metadata_common

--- a/docs/metadata_common.rst
+++ b/docs/metadata_common.rst
@@ -1,0 +1,5 @@
+##################
+The Common Section
+##################
+
+.. jsonschema:: ../schema/common.schema.json

--- a/docs/metadata_languages.rst
+++ b/docs/metadata_languages.rst
@@ -2,37 +2,4 @@
 The Languages Section
 #####################
 
-One languages element is allowed for all flavorTypes and required for scripture and gloss flavorTypes. The languages represented
-are those used in the content. (The metadata may include localization in other languages.)
-
-.. code-block:: xml
-
-    <languages>
-        <language>
-            <bcp47>fr</bcp47>
-            <name lang="fr">français</name>
-            <name lang="en">French</name>
-            <name lang="de">Französisch</name>
-            <scriptDirection>LTR</scriptDirection>
-        </language>
-        <language>
-            <bcp47>en</bcp47>
-            <name lang="en">English</name>
-            <scriptDirection>LTR</scriptDirection>
-        </language>
-    </languages>
-
-bcp47
-=====
-
-The BCP 47 code for the language (https://tools.ietf.org/html/bcp47).
-
-scriptDirection
-===============
-
-LTR or RTL.
-
-rod
-===
-
-The optional ROD for the language (http://globalrecordings.net/en/rod).
+.. jsonschema:: ../schema/language.schema.json

--- a/schema/common.schema.json
+++ b/schema/common.schema.json
@@ -1,6 +1,11 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://burrito.bible/schema/common.schema.json",
+    "$$target": [
+        "common.schema.json#/definitions/languageTag",
+        "common.schema.json#/definitions/localizedText",
+        "common.schema.json#/definitions/rodCode"
+    ],
     "title": "Scripture Burrito Common Definitions",
     "description": "Common definitions for use by other parts of the schema.",
     "definitions": {
@@ -9,7 +14,8 @@
             "format": "uri",
             "pattern": "^(https?|ftp)://[^\\s/$.?#].[^\\s]*$",
             "minLength": 1,
-            "description": "A valid Uniform Resource Locator."
+            "description": "A valid **Uniform Resource Locator**.",
+            "examples": ["https://example.com"]
         },
         "xToken": {
             "type": "string",

--- a/schema/language.schema.json
+++ b/schema/language.schema.json
@@ -5,7 +5,10 @@
     "type": "object",
     "description": "Language section.",
     "properties": {
-        "tag": {"$ref": "common.schema.json#/definitions/languageTag"},
+        "tag": {
+            "$ref": "common.schema.json#/definitions/languageTag",
+             "examples": ["hi", "es-419"]
+            },
         "name": {"$ref": "common.schema.json#/definitions/localizedText"},
         "rod": {"$ref": "common.schema.json#/definitions/rodCode"},
         "scriptDirection": {


### PR DESCRIPTION
This addresses #71 

This is an example of what it would look like to use sphinx-jsonschema to generate our documentation.  Note that I've only built a metadata_common page and I've modified the metadata_languages page.

It's only possible to link to a top level schema file, not a specific definition therein. So the three links in [langauge.schema.json](https://github.com/bible-technology/scripture-burrito/blob/sphinx-jsonschema_example/schema/language.schema.json#L9-L13) only point to the top of the Common page. I think it would be valuable if we could layout the connections in such a way that we could link directly to the field being referenced. Brief documentation for how this works is at https://pypi.org/project/sphinx-jsonschema/.