### PR TITLE
Timestamps for meta uploader and generator

### DIFF
--- a/docs/examples/artifacts/textTranslation.json
+++ b/docs/examples/artifacts/textTranslation.json
@@ -4,13 +4,15 @@
         "generator": {
             "softwareName": "Burrito Factory",
             "softwareVersion": "0.1",
-            "userName": "Jane Doe"
+            "userName": "Jane Doe",
+            "timestamp": "2020-02-18T23:59:59+01:00"
         },
         "uploader": {
             "softwareName": "Burrito Truck",
             "softwareVersion": "0.1",
             "userId": "dbl::5678",
-            "userName": "Josh Buck"
+            "userName": "Josh Buck",
+            "timestamp": "2020-02-19T00:00:01+01:00"
         },
         "defaultLanguage": "en",
         "comments": [

--- a/docs/examples/artifacts/textTranslation.json
+++ b/docs/examples/artifacts/textTranslation.json
@@ -1,18 +1,17 @@
 {
     "meta": {
         "version": "0.2.0",
+        "dateCreated": "2019-02-19T01:02:03+01:00",
         "generator": {
             "softwareName": "Burrito Factory",
             "softwareVersion": "0.1",
-            "userName": "Jane Doe",
-            "timestamp": "2020-02-18T23:59:59+01:00"
+            "userName": "Jane Doe"
         },
         "uploader": {
             "softwareName": "Burrito Truck",
             "softwareVersion": "0.1",
             "userId": "dbl::5678",
-            "userName": "Josh Buck",
-            "timestamp": "2020-02-19T00:00:01+01:00"
+            "userName": "Josh Buck"
         },
         "defaultLanguage": "en",
         "comments": [

--- a/schema/meta.schema.json
+++ b/schema/meta.schema.json
@@ -23,21 +23,20 @@
                 "userName": {
                     "type": "string",
                     "description": "The user's full name, if known."
-                },
-                "timestamp": {
-                    "type": "string",
-                    "format": "date-time"
                 }
             },
             "required": [
                 "softwareName",
-                "softwareVersion",
-                "timestamp"
+                "softwareVersion"
             ],
             "additionalProperties": false
         }
     },
     "properties": {
+        "dateCreated": {
+            "type": "string",
+            "format": "date-time"
+        },
         "version": {
             "type": "string",
             "pattern": "^[0-9]+(\\.[0-9]+)*$",
@@ -65,6 +64,7 @@
     },
     "required": [
         "version",
+        "dateCreated",
         "defaultLanguage"
     ],
     "additionalProperties": false

--- a/schema/meta.schema.json
+++ b/schema/meta.schema.json
@@ -23,11 +23,16 @@
                 "userName": {
                     "type": "string",
                     "description": "The user's full name, if known."
+                },
+                "timestamp": {
+                    "type": "string",
+                    "format": "date-time"
                 }
             },
             "required": [
                 "softwareName",
-                "softwareVersion"
+                "softwareVersion",
+                "timestamp"
             ],
             "additionalProperties": false
         }


### PR DESCRIPTION
This information turns out to be rather important since there's no other way to find the latest revision (now that revisions are not incrementing integers).

#125 and maybe #126 should be merged first.