### PR TITLE
Lower case canon component enums

### DIFF
--- a/code/.gitignore
+++ b/code/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/code/validate.py
+++ b/code/validate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os.path
 import json

--- a/docs/examples/artifacts/textTranslation.json
+++ b/docs/examples/artifacts/textTranslation.json
@@ -78,7 +78,7 @@
                 "MAT": "1,5,7-11"
             },
             "canonType": [
-		"ot",
+                "ot",
                 "nt"
             ],
             "canonSpec": {

--- a/docs/examples/artifacts/textTranslation.json
+++ b/docs/examples/artifacts/textTranslation.json
@@ -78,14 +78,14 @@
                 "MAT": "1,5,7-11"
             },
             "canonType": [
-                "OT",
-                "NT"
+		"ot",
+                "nt"
             ],
             "canonSpec": {
-                "OT": {
+                "ot": {
                     "name": "western"
                 },
-                "NT": {
+                "nt": {
                     "name": "x-matthewOnlyMillenialists",
                     "books": [
                         "MAT"

--- a/schema/canon_spec.schema.json
+++ b/schema/canon_spec.schema.json
@@ -27,10 +27,10 @@
                 ]
             }
         },
-        "canonComponentOT+": {
+        "canonComponentOTDC": {
             "$$target": [
-                "type.schema.json#/definitions/canonComponentOT+",
-                "#/definitions/canonComponentOT+"
+                "type.schema.json#/definitions/canonComponentOTDC",
+                "#/definitions/canonComponentOTDC"
             ],
             "title": "Old Testament+ Canon Component",
             "properties": {
@@ -57,7 +57,7 @@
                     "books"
                 ]
             },
-            "$comment": "OT+ is OT with interleaved DC"
+            "$comment": "OTDC is OT with interleaved DC"
         },
         "canonComponentDC": {
             "$$target": [
@@ -307,7 +307,7 @@
         }
     },
     "properties": {
-        "OT": {
+        "ot": {
             "type": "object",
             "properties": {
                 "books": {
@@ -328,7 +328,7 @@
                 "name"
             ]
         },
-        "OT+": {
+        "otdc": {
             "type": "object",
             "properties": {
                 "books": {
@@ -339,7 +339,7 @@
             },
             "oneOf": [
                 {
-                    "$ref": "#/definitions/canonComponentOT+"
+                    "$ref": "#/definitions/canonComponentOTDC"
                 },
                 {
                     "$ref": "#/definitions/canonComponentCustom"
@@ -349,7 +349,7 @@
                 "name"
             ]
         },
-        "DC": {
+        "dc": {
             "type": "object",
             "properties": {
                 "books": {
@@ -370,7 +370,7 @@
                 "name"
             ]
         },
-        "NT": {
+        "nt": {
             "type": "object",
             "properties": {
                 "books": {
@@ -398,19 +398,19 @@
         {
             "not": {
                 "required": [
-                    "OT",
-                    "OT+"
+                    "ot",
+                    "otdc"
                 ]
             }
         },
         {
             "not": {
                 "required": [
-                    "DC",
-                    "OT+"
+                    "dc",
+                    "otdc"
                 ]
             }
         }
     ],
-    "$comment": "OT or DC may not be specified if OT+ is present."
+    "$comment": "ot or dc may not be specified if otdc is present."
 }

--- a/schema/canon_type.schema.json
+++ b/schema/canon_type.schema.json
@@ -3,37 +3,35 @@
     "$id": "https://burrito.bible/schema/canon_type.schema.json",
     "title": "Scripture Burrito Canon Type",
     "type": "array",
-    "enum": [
-        [
-            "DC"
-        ],
-        [
-            "NT"
-        ],
-        [
-            "OT",
-            "DC",
-            "NT"
-        ],
-        [
-            "OT",
-            "NT",
-            "DC"
-        ],
-        [
-            "OT",
-            "NT"
-        ],
-        [
-            "OT+",
-            "NT"
-        ],
-        [
-            "OT"
-        ],
-        [
-            "OT+"
-        ]
+    "items": {
+	"type": "string",
+	"enum": ["ot", "otdc", "dc", "nt"]
+    },
+    "allOf": [
+	{
+	    "not": {
+		"allOf": [
+		    {
+			"contains": {"const": "ot"}
+		    },
+		    {
+			"contains": {"const": "otdc"}
+		    }
+		]
+	    }
+	},
+	{
+	    "not": {
+		"allOf": [
+		    {
+			"contains": {"const": "dc"}
+		    },
+		    {
+			"contains": {"const": "otdc"}
+		    }
+		]
+	    }
+	}
     ],
     "minItems": 1,
     "maxItems": 3,

--- a/schema/canon_type.schema.json
+++ b/schema/canon_type.schema.json
@@ -4,34 +4,47 @@
     "title": "Scripture Burrito Canon Type",
     "type": "array",
     "items": {
-	"type": "string",
-	"enum": ["ot", "otdc", "dc", "nt"]
+        "type": "string",
+        "enum": [
+            "ot",
+            "otdc",
+            "dc",
+            "nt"
+        ]
     },
     "allOf": [
-	{
-	    "not": {
-		"allOf": [
-		    {
-			"contains": {"const": "ot"}
-		    },
-		    {
-			"contains": {"const": "otdc"}
-		    }
-		]
-	    }
-	},
-	{
-	    "not": {
-		"allOf": [
-		    {
-			"contains": {"const": "dc"}
-		    },
-		    {
-			"contains": {"const": "otdc"}
-		    }
-		]
-	    }
-	}
+        {
+            "not": {
+                "allOf": [
+                    {
+                        "contains": {
+                            "const": "ot"
+                        }
+                    },
+                    {
+                        "contains": {
+                            "const": "otdc"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "not": {
+                "allOf": [
+                    {
+                        "contains": {
+                            "const": "dc"
+                        }
+                    },
+                    {
+                        "contains": {
+                            "const": "otdc"
+                        }
+                    }
+                ]
+            }
+        }
     ],
     "minItems": 1,
     "maxItems": 3,


### PR DESCRIPTION
This PR changes canon component enums to

```
ot, otdc, dc, nt
```
with constraints to avoid, eg, both ot and otdc.

Related to #104 