### PR TITLE
Source is the new Variant

### DIFF
--- a/docs/examples/artifacts/textTranslation_derived.json
+++ b/docs/examples/artifacts/textTranslation_derived.json
@@ -1,7 +1,7 @@
 {
     "meta": {
         "version": "0.2.0",
-        "variant": "source",
+        "variant": "derived_foo",
         "dateCreated": "2019-02-19T01:02:03+01:00",
         "generator": {
             "softwareName": "Burrito Factory",
@@ -187,6 +187,11 @@
             1
         ],
         "rightsAdminAgency": 1,
+        "licenses": [
+            {
+                "url": "https://burritos-r-us.org/licenses/3247"
+            }
+        ],
         "shortStatementPlain": {
             "fr": "\u00a9 Burritos R Us 2019."
         },
@@ -415,9 +420,5 @@
                 "fr": "A propos de Matthieu"
             }
         }
-    },
-    "progress": {
-        "dateStarted": "2017-11-30",
-        "dateCompleted": "2017-12-01"
     }
 }

--- a/schema/index.js
+++ b/schema/index.js
@@ -13,8 +13,6 @@ module.exports = {
         require('./copyright.schema.json'),
         require('./countries.schema.json'),
         require('./country.schema.json'),
-        require('./default_meta.schema.json'),
-        require('./default_metadata.schema.json'),
         require('./derived_meta.schema.json'),
         require('./derived_metadata.schema.json'),
         require('./gloss/text_stories.schema.json'),
@@ -47,6 +45,8 @@ module.exports = {
 	require('./scripture/text_translation.schema.json'),
         require('./scope.schema.json'),
         require('./software_and_user_info.schema.json'),
+        require('./source_meta.schema.json'),
+        require('./source_metadata.schema.json'),
         require('./type.schema.json'),
 	require('./x_flavor.schema.json')
     ]

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -6,7 +6,7 @@
     "description": "Scripture Burrito root metadata object.",
     "oneOf": [
         {
-            "$ref": "default_metadata.schema.json"
+            "$ref": "source_metadata.schema.json"
         },
         {
             "$ref": "derived_metadata.schema.json"

--- a/schema/source_meta.schema.json
+++ b/schema/source_meta.schema.json
@@ -1,14 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://burrito.bible/schema/default_meta.schema.json",
+    "$id": "https://burrito.bible/schema/source_meta.schema.json",
     "title": "Scripture Burrito Meta (Default)",
     "type": "object",
     "description": "Information about the Scripture Burrito metadata file (default variant).",
     "properties": {
         "variant": {
             "type": "string",
-            "const": "default",
-            "description": "The type of variant represented in the burrito (which must be 'default')"
+            "const": "source",
+            "description": "The type of variant represented in the burrito (which must be 'source' which we pretend is'nt a variant even though it kinda is really)."
         },
         "dateCreated": {
             "$ref": "meta_date_created.schema.json"

--- a/schema/source_metadata.schema.json
+++ b/schema/source_metadata.schema.json
@@ -1,12 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://burrito.bible/schema/default_metadata.schema.json",
+    "$id": "https://burrito.bible/schema/source_metadata.schema.json",
     "title": "Scripture Burrito Metadata (Default)",
     "type": "object",
-    "description": "Scripture Burrito default variant root.",
+    "description": "Scripture Burrito source kinda-variant root.",
     "properties": {
         "meta": {
-            "$ref": "default_meta.schema.json"
+            "$ref": "source_meta.schema.json"
         },
         "idServers": {
             "$ref": "idservers.schema.json"


### PR DESCRIPTION
This PR changes "default" to "source". This meant renaming schema documents, changing links, and also spinning up a (currently uninteresting) derived test document. These changes should pave the way for flashing out recipeSpecs and recipes.