### PR TITLE
Use more complete BCP 47 validation regex

### DIFF
--- a/schema/common.schema.json
+++ b/schema/common.schema.json
@@ -50,7 +50,7 @@
         },
         "languageTag": {
             "type": "string",
-            "pattern": "^[A-Za-z]{2,3}([\\-_][A-Za-z0-9]+){0,4}$",
+            "pattern": "^(((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+))$",
             "minLength": 2,
             "description": "A valid IETF language tag as specified by BCP 47."
         },


### PR DESCRIPTION
The current BCP 47 regex was just inherited from wherever it was taken from.  This replaces it with a more complete RegEx, taken from [this StackOverflow answer](https://stackoverflow.com/a/7036171/2135754).

This regular expression is fairly relaxed and case-insensitive.  We may want to reconsider that.  I'll open a separate issue to discuss this.