### PR TITLE
Roles; Normalization; Less oneOf; Enums for Audio; Template Schema; Braille Example

### DIFF
--- a/docs/examples/artifacts/audioTranslation.json
+++ b/docs/examples/artifacts/audioTranslation.json
@@ -50,7 +50,7 @@
       "name": "scripture",
       "flavor": {
         "name": "audioTranslation",
-        "performance": ["multipleVoice", "drama", "withMusic"],
+          "performance": ["multipleVoice", "drama", "withMusic"],
         "formats": {
           "format1": {
             "compression": "mp3",

--- a/docs/examples/artifacts/audioTranslation.json
+++ b/docs/examples/artifacts/audioTranslation.json
@@ -50,7 +50,7 @@
       "name": "scripture",
       "flavor": {
         "name": "audioTranslation",
-        "dramatization": "singleVoice",
+        "performance": ["multipleVoice", "drama", "withMusic"],
         "formats": {
           "format1": {
             "compression": "mp3",

--- a/docs/examples/artifacts/embossedBrailleScripture.json
+++ b/docs/examples/artifacts/embossedBrailleScripture.json
@@ -1,0 +1,1154 @@
+{
+    "meta": {
+        "version": "0.2.0",
+        "variant": "source",
+        "generator": {
+            "softwareName": "DBLImport",
+            "softwareVersion": "0.0.0",
+            "userName": "Jake Kyle"
+        },
+        "defaultLanguage": "en",
+        "dateCreated": "2019-07-17T08:00:56.467963+00:00",
+        "comments": [
+            "Braille test"
+        ]
+    },
+    "idServers": {
+        "dbl": {
+            "id": "https://thedigitalbiblelibrary.org",
+            "name": {
+                "en": "The Digital Bible Library"
+            }
+        }
+    },
+    "identification": {
+        "systemId": {
+            "dbl": {
+                "id": "865ab834004f4186",
+                "revision": "3"
+            }
+        },
+        "idServer": "dbl",
+        "name": {
+            "en": "WEBBE Braille"
+        },
+        "description": {
+            "en": "British/International spelling edition of the World English Bible in Braille"
+        },
+        "abbreviation": {
+            "en": "WEBBEBRL"
+        }
+    },
+    "languages": [
+        {
+            "tag": "en",
+            "name": {
+                "en": "English"
+            }
+        }
+    ],
+    "relationships": [
+        {
+            "relationType": "source",
+            "flavor": "textTranslation",
+            "id": "dbl::7142879509583d59",
+            "revision": "9",
+            "variant": "p4"
+        }
+    ],
+    "type": {
+        "flavorType": {
+            "name": "scripture",
+            "flavor": {
+                "name": "embossedBrailleScripture",
+                "isContracted": true,
+                "processor": {
+                    "name": "libLouis",
+                    "table": {
+                        "src": "en-ueb-g2.ctb",
+                        "name": "Unified English Braille Grade 2"
+                    },
+                    "version": "3.9.0"
+                },
+                "numberSign": {
+                    "character": "⠼",
+                    "useInMargin": false
+                },
+                "content": {
+                    "chapterNumberStyle": "upper",
+                    "chapterHeadingsNumberFirst": false,
+                    "versedParagraphs": false,
+                    "verseSeparator": "⠀⠀",
+                    "includeIntros": true
+                },
+                "page": {
+                    "charsPerLine": 36,
+                    "linesPerPage": 28,
+                    "defaultMarginWidth": 3,
+                    "versoLastLineBlank": false,
+                    "carryLines": 2
+                }
+            },
+            "canonType": [
+                "ot",
+                "nt"
+            ],
+            "canonSpec": {
+                "ot": {
+                    "name": "western"
+                },
+                "nt": {
+                    "name": "western"
+                }
+            },
+            "currentScope": {
+                "JHN": []
+            }
+        }
+    },
+    "confidentiality": {
+        "metadata": "unrestricted",
+        "ingredients": "restricted"
+    },
+    "agencies": [
+        {
+            "id": "dbl::b78a0b882a8a372c837d68b7",
+            "roles": [
+                "rightsHolder",
+                "content",
+                "publication",
+                "finance",
+                "qa"
+            ],
+            "url": "https://www.compassbraille.org/",
+            "name": {
+                "en": "Compass Braille"
+            },
+            "abbr": {
+                "en": "CB"
+            }
+        },
+        {
+            "id": "dbl::545d2cb0ae307afa44b390fc",
+            "roles": [
+                "content",
+                "publication",
+                "management",
+                "finance",
+                "qa"
+            ],
+            "name": {
+                "en": "eBible.org"
+            }
+        }
+    ],
+    "targetAreas": [
+        {
+            "code": "GB",
+            "name": {
+                "en": "United Kingdom"
+            }
+        }
+    ],
+    "names": {
+        "i18n-contents": {
+            "short": {
+                "en": "Contents"
+            }
+        },
+        "i18n-psalm": {
+            "short": {
+                "en": "Psalm"
+            }
+        },
+        "i18n-chapter": {
+            "short": {
+                "en": "Chapter"
+            }
+        },
+        "i18n-chapters": {
+            "short": {
+                "en": "Chapters"
+            }
+        },
+        "i18n-braille_producer_statement": {
+            "short": {
+                "en": "Produced in Braille by Compass Braille UK"
+            }
+        },
+        "book-gen": {
+            "abbr": {
+                "en": "Genesis"
+            },
+            "short": {
+                "en": "Genesis"
+            },
+            "long": {
+                "en": "The First Book of Moses, Commonly Called Genesis"
+            }
+        },
+        "book-exo": {
+            "abbr": {
+                "en": "Exodus"
+            },
+            "short": {
+                "en": "Exodus"
+            },
+            "long": {
+                "en": "The Second Book of Mosis, Commonly Called Exodus"
+            }
+        },
+        "book-lev": {
+            "abbr": {
+                "en": "Leviticus"
+            },
+            "short": {
+                "en": "Leviticus"
+            },
+            "long": {
+                "en": "The Third Book of Mosis, Commonly Called Leviticus"
+            }
+        },
+        "book-num": {
+            "abbr": {
+                "en": "Numbers"
+            },
+            "short": {
+                "en": "Numbers"
+            },
+            "long": {
+                "en": "The Fourth Book of Moses, Commonly Called Numbers"
+            }
+        },
+        "book-deu": {
+            "abbr": {
+                "en": "Deuteronomy"
+            },
+            "short": {
+                "en": "Deuteronomy"
+            },
+            "long": {
+                "en": "The Fifth Book of Moses, Commonly Called Deuteronomy"
+            }
+        },
+        "book-jos": {
+            "abbr": {
+                "en": "Joshua"
+            },
+            "short": {
+                "en": "Joshua"
+            },
+            "long": {
+                "en": "The Book of Joshua"
+            }
+        },
+        "book-jdg": {
+            "abbr": {
+                "en": "Judges"
+            },
+            "short": {
+                "en": "Judges"
+            },
+            "long": {
+                "en": "The Book of Judges"
+            }
+        },
+        "book-rut": {
+            "abbr": {
+                "en": "Ruth"
+            },
+            "short": {
+                "en": "Ruth"
+            },
+            "long": {
+                "en": "The Book of Ruth"
+            }
+        },
+        "book-1sa": {
+            "abbr": {
+                "en": "1 Samuel"
+            },
+            "short": {
+                "en": "1 Samuel"
+            },
+            "long": {
+                "en": "The First Book of Samuel"
+            }
+        },
+        "book-2sa": {
+            "abbr": {
+                "en": "2 Samuel"
+            },
+            "short": {
+                "en": "2 Samuel"
+            },
+            "long": {
+                "en": "The Second Book of Samuel"
+            }
+        },
+        "book-1ki": {
+            "abbr": {
+                "en": "1 Kings"
+            },
+            "short": {
+                "en": "1 Kings"
+            },
+            "long": {
+                "en": "The First Book of Kings"
+            }
+        },
+        "book-2ki": {
+            "abbr": {
+                "en": "2 Kings"
+            },
+            "short": {
+                "en": "2 Kings"
+            },
+            "long": {
+                "en": "The Second Book of Kings"
+            }
+        },
+        "book-1ch": {
+            "abbr": {
+                "en": "1 Chronicles"
+            },
+            "short": {
+                "en": "1 Chronicles"
+            },
+            "long": {
+                "en": "The First Book of Chronicles"
+            }
+        },
+        "book-2ch": {
+            "abbr": {
+                "en": "2 Chronicles"
+            },
+            "short": {
+                "en": "2 Chronicles"
+            },
+            "long": {
+                "en": "The Second Book of Chronicles"
+            }
+        },
+        "book-ezr": {
+            "abbr": {
+                "en": "Ezra"
+            },
+            "short": {
+                "en": "Ezra"
+            },
+            "long": {
+                "en": "The Book of Ezra"
+            }
+        },
+        "book-neh": {
+            "abbr": {
+                "en": "Nehemiah"
+            },
+            "short": {
+                "en": "Nehemiah"
+            },
+            "long": {
+                "en": "The Book of Nehemiah"
+            }
+        },
+        "book-est": {
+            "abbr": {
+                "en": "Esther"
+            },
+            "short": {
+                "en": "Esther"
+            },
+            "long": {
+                "en": "The Book of Esther"
+            }
+        },
+        "book-job": {
+            "abbr": {
+                "en": "Job"
+            },
+            "short": {
+                "en": "Job"
+            },
+            "long": {
+                "en": "The Book of Job"
+            }
+        },
+        "book-psa": {
+            "abbr": {
+                "en": "Psalm"
+            },
+            "short": {
+                "en": "Psalms"
+            },
+            "long": {
+                "en": "The Psalms"
+            }
+        },
+        "book-pro": {
+            "abbr": {
+                "en": "Proverbs"
+            },
+            "short": {
+                "en": "Proverbs"
+            },
+            "long": {
+                "en": "The Proverbs"
+            }
+        },
+        "book-ecc": {
+            "abbr": {
+                "en": "Ecclesiastes"
+            },
+            "short": {
+                "en": "Ecclesiastes"
+            },
+            "long": {
+                "en": "Ecclesiates or, The Preacher"
+            }
+        },
+        "book-sng": {
+            "abbr": {
+                "en": "Song of Solomon"
+            },
+            "short": {
+                "en": "Song of Solomon"
+            },
+            "long": {
+                "en": "The Song of Solomon"
+            }
+        },
+        "book-isa": {
+            "abbr": {
+                "en": "Isaiah"
+            },
+            "short": {
+                "en": "Isaiah"
+            },
+            "long": {
+                "en": "The Book of Isaiah"
+            }
+        },
+        "book-jer": {
+            "abbr": {
+                "en": "Jeremiah"
+            },
+            "short": {
+                "en": "Jeremiah"
+            },
+            "long": {
+                "en": "The Book of Jeremiah"
+            }
+        },
+        "book-lam": {
+            "abbr": {
+                "en": "Lamentations"
+            },
+            "short": {
+                "en": "Lamentations"
+            },
+            "long": {
+                "en": "The Lamentations of Jeremiah"
+            }
+        },
+        "book-ezk": {
+            "abbr": {
+                "en": "Ezekiel"
+            },
+            "short": {
+                "en": "Ezekiel"
+            },
+            "long": {
+                "en": "The Book of Ezekiel"
+            }
+        },
+        "book-dan": {
+            "abbr": {
+                "en": "Daniel"
+            },
+            "short": {
+                "en": "Daniel"
+            },
+            "long": {
+                "en": "The Book of Daniel"
+            }
+        },
+        "book-hos": {
+            "abbr": {
+                "en": "Hosea"
+            },
+            "short": {
+                "en": "Hosea"
+            },
+            "long": {
+                "en": "The Book of Hosea"
+            }
+        },
+        "book-jol": {
+            "abbr": {
+                "en": "Joel"
+            },
+            "short": {
+                "en": "Joel"
+            },
+            "long": {
+                "en": "The Book of Joel"
+            }
+        },
+        "book-amo": {
+            "abbr": {
+                "en": "Amos"
+            },
+            "short": {
+                "en": "Amos"
+            },
+            "long": {
+                "en": "The Book of Amos"
+            }
+        },
+        "book-oba": {
+            "abbr": {
+                "en": "Obadiah"
+            },
+            "short": {
+                "en": "Obadiah"
+            },
+            "long": {
+                "en": "The Book of Obadiah"
+            }
+        },
+        "book-jon": {
+            "abbr": {
+                "en": "Jonah"
+            },
+            "short": {
+                "en": "Jonah"
+            },
+            "long": {
+                "en": "The Book of Jonah"
+            }
+        },
+        "book-mic": {
+            "abbr": {
+                "en": "Micah"
+            },
+            "short": {
+                "en": "Micah"
+            },
+            "long": {
+                "en": "The Book of Micah"
+            }
+        },
+        "book-nam": {
+            "abbr": {
+                "en": "Nahum"
+            },
+            "short": {
+                "en": "Nahum"
+            },
+            "long": {
+                "en": "The Book of Nahum"
+            }
+        },
+        "book-hab": {
+            "abbr": {
+                "en": "Habakkuk"
+            },
+            "short": {
+                "en": "Habakkuk"
+            },
+            "long": {
+                "en": "The Book of Habakkuk"
+            }
+        },
+        "book-zep": {
+            "abbr": {
+                "en": "Zephaniah"
+            },
+            "short": {
+                "en": "Zephaniah"
+            },
+            "long": {
+                "en": "The Book of Zephaniah"
+            }
+        },
+        "book-hag": {
+            "abbr": {
+                "en": "Haggai"
+            },
+            "short": {
+                "en": "Haggai"
+            },
+            "long": {
+                "en": "The Book of Haggai"
+            }
+        },
+        "book-zec": {
+            "abbr": {
+                "en": "Zechariah"
+            },
+            "short": {
+                "en": "Zechariah"
+            },
+            "long": {
+                "en": "The Book of Zechariah"
+            }
+        },
+        "book-mal": {
+            "abbr": {
+                "en": "Malachi"
+            },
+            "short": {
+                "en": "Malachi"
+            },
+            "long": {
+                "en": "The Book of Malachi"
+            }
+        },
+        "book-mat": {
+            "abbr": {
+                "en": "Matthew"
+            },
+            "short": {
+                "en": "Matthew"
+            },
+            "long": {
+                "en": "The Good News According to Matthew"
+            }
+        },
+        "book-mrk": {
+            "abbr": {
+                "en": "Mark"
+            },
+            "short": {
+                "en": "Mark"
+            },
+            "long": {
+                "en": "The Good News According to Mark"
+            }
+        },
+        "book-luk": {
+            "abbr": {
+                "en": "Luke"
+            },
+            "short": {
+                "en": "Luke"
+            },
+            "long": {
+                "en": "The Good News According to Luke"
+            }
+        },
+        "book-jhn": {
+            "abbr": {
+                "en": "John"
+            },
+            "short": {
+                "en": "John"
+            },
+            "long": {
+                "en": "The Good News According to John"
+            }
+        },
+        "book-act": {
+            "abbr": {
+                "en": "Acts"
+            },
+            "short": {
+                "en": "Acts"
+            },
+            "long": {
+                "en": "The Acts of the Apostles"
+            }
+        },
+        "book-rom": {
+            "abbr": {
+                "en": "Romans"
+            },
+            "short": {
+                "en": "Romans"
+            },
+            "long": {
+                "en": "Paul’s Letter to the Romans"
+            }
+        },
+        "book-1co": {
+            "abbr": {
+                "en": "1 Corinthians"
+            },
+            "short": {
+                "en": "1 Corinthians"
+            },
+            "long": {
+                "en": "Paul’s First Letter to the Corinthians"
+            }
+        },
+        "book-2co": {
+            "abbr": {
+                "en": "2 Corinthians"
+            },
+            "short": {
+                "en": "2 Corinthians"
+            },
+            "long": {
+                "en": "Paul’s Second Letter to the Corinthians"
+            }
+        },
+        "book-gal": {
+            "abbr": {
+                "en": "Galatians"
+            },
+            "short": {
+                "en": "Galatians"
+            },
+            "long": {
+                "en": "Paul’s Letter to the Galatians"
+            }
+        },
+        "book-eph": {
+            "abbr": {
+                "en": "Ephesians"
+            },
+            "short": {
+                "en": "Ephesians"
+            },
+            "long": {
+                "en": "Paul’s Letter to the Ephesians"
+            }
+        },
+        "book-php": {
+            "abbr": {
+                "en": "Philippians"
+            },
+            "short": {
+                "en": "Philippians"
+            },
+            "long": {
+                "en": "Paul’s Letter to the Philippians"
+            }
+        },
+        "book-col": {
+            "abbr": {
+                "en": "Colossians"
+            },
+            "short": {
+                "en": "Colossians"
+            },
+            "long": {
+                "en": "Paul’s Letter to the Colossians"
+            }
+        },
+        "book-1th": {
+            "abbr": {
+                "en": "1 Thessalonians"
+            },
+            "short": {
+                "en": "1 Thessalonians"
+            },
+            "long": {
+                "en": "Paul’s First Letter to the Thessalonians"
+            }
+        },
+        "book-2th": {
+            "abbr": {
+                "en": "2 Thessalonians"
+            },
+            "short": {
+                "en": "2 Thessalonians"
+            },
+            "long": {
+                "en": "Paul’s Second Letter to the Thessalonians"
+            }
+        },
+        "book-1ti": {
+            "abbr": {
+                "en": "1 Timothy"
+            },
+            "short": {
+                "en": "1 Timothy"
+            },
+            "long": {
+                "en": "Paul’s First Letter to Timothy"
+            }
+        },
+        "book-2ti": {
+            "abbr": {
+                "en": "2 Timothy"
+            },
+            "short": {
+                "en": "2 Timothy"
+            },
+            "long": {
+                "en": "Paul’s Second Letter to Timothy"
+            }
+        },
+        "book-tit": {
+            "abbr": {
+                "en": "Titus"
+            },
+            "short": {
+                "en": "Titus"
+            },
+            "long": {
+                "en": "Paul’s Letter to Titus"
+            }
+        },
+        "book-phm": {
+            "abbr": {
+                "en": "Philemon"
+            },
+            "short": {
+                "en": "Philemon"
+            },
+            "long": {
+                "en": "Paul’s Letter to Philemon"
+            }
+        },
+        "book-heb": {
+            "abbr": {
+                "en": "Hebrews"
+            },
+            "short": {
+                "en": "Hebrews"
+            },
+            "long": {
+                "en": "The Letter to the Hebrews"
+            }
+        },
+        "book-jas": {
+            "abbr": {
+                "en": "James"
+            },
+            "short": {
+                "en": "James"
+            },
+            "long": {
+                "en": "The Letter from James"
+            }
+        },
+        "book-1pe": {
+            "abbr": {
+                "en": "1 Peter"
+            },
+            "short": {
+                "en": "1 Peter"
+            },
+            "long": {
+                "en": "Peter’s First Letter"
+            }
+        },
+        "book-2pe": {
+            "abbr": {
+                "en": "2 Peter"
+            },
+            "short": {
+                "en": "2 Peter"
+            },
+            "long": {
+                "en": "Peter’s Second Letter"
+            }
+        },
+        "book-1jn": {
+            "abbr": {
+                "en": "1 John"
+            },
+            "short": {
+                "en": "1 John"
+            },
+            "long": {
+                "en": "John’s First Letter"
+            }
+        },
+        "book-2jn": {
+            "abbr": {
+                "en": "2 John"
+            },
+            "short": {
+                "en": "2 John"
+            },
+            "long": {
+                "en": "John’s Second Letter"
+            }
+        },
+        "book-3jn": {
+            "abbr": {
+                "en": "3 John"
+            },
+            "short": {
+                "en": "3 John"
+            },
+            "long": {
+                "en": "John’s Third Letter"
+            }
+        },
+        "book-jud": {
+            "abbr": {
+                "en": "Jude"
+            },
+            "short": {
+                "en": "Jude"
+            },
+            "long": {
+                "en": "The Letter from Jude"
+            }
+        },
+        "book-rev": {
+            "abbr": {
+                "en": "Revelation"
+            },
+            "short": {
+                "en": "Revelation"
+            },
+            "long": {
+                "en": "The Revelation to John"
+            }
+        },
+        "book-tob": {
+            "abbr": {
+                "en": "Tobit"
+            },
+            "short": {
+                "en": "Tobit"
+            },
+            "long": {
+                "en": "Tobit"
+            }
+        },
+        "book-jdt": {
+            "abbr": {
+                "en": "Judith"
+            },
+            "short": {
+                "en": "Judith"
+            },
+            "long": {
+                "en": "Judith"
+            }
+        },
+        "book-esg": {
+            "abbr": {
+                "en": "ESG"
+            },
+            "short": {
+                "en": "Esther (Greek)"
+            },
+            "long": {
+                "en": "Esther (Greek)"
+            }
+        },
+        "book-wis": {
+            "abbr": {
+                "en": "Wisdom"
+            },
+            "short": {
+                "en": "Wisdom of Solomon"
+            },
+            "long": {
+                "en": "The Wisdom of Solomon"
+            }
+        },
+        "book-sir": {
+            "abbr": {
+                "en": "Sirach"
+            },
+            "short": {
+                "en": "Sirach"
+            },
+            "long": {
+                "en": "The Wisdom of Jesus the Son of Sirach, or Ecclesiasticus"
+            }
+        },
+        "book-bar": {
+            "abbr": {
+                "en": "Baruch"
+            },
+            "short": {
+                "en": "Baruch"
+            },
+            "long": {
+                "en": "Baruch"
+            }
+        },
+        "book-1ma": {
+            "abbr": {
+                "en": "1Ma"
+            },
+            "short": {
+                "en": "1 Maccabees"
+            },
+            "long": {
+                "en": "The First Book of the Maccabees"
+            }
+        },
+        "book-2ma": {
+            "abbr": {
+                "en": "2Ma"
+            },
+            "short": {
+                "en": "2 Maccabees"
+            },
+            "long": {
+                "en": "The Second Book of the Maccabees"
+            }
+        },
+        "book-3ma": {
+            "abbr": {
+                "en": "3Ma"
+            },
+            "short": {
+                "en": "3 Maccabees"
+            },
+            "long": {
+                "en": "The Third Book of the Maccabees"
+            }
+        },
+        "book-4ma": {
+            "abbr": {
+                "en": "4Ma"
+            },
+            "short": {
+                "en": "4 Maccabees"
+            },
+            "long": {
+                "en": "The Fourth Book of the Maccabees"
+            }
+        },
+        "book-1es": {
+            "abbr": {
+                "en": "1Es"
+            },
+            "short": {
+                "en": "1 Esdras"
+            },
+            "long": {
+                "en": "1 Esdras"
+            }
+        },
+        "book-2es": {
+            "abbr": {
+                "en": "2Es"
+            },
+            "short": {
+                "en": "2 Esdras"
+            },
+            "long": {
+                "en": "2 Esdras"
+            }
+        },
+        "book-man": {
+            "abbr": {
+                "en": "Man"
+            },
+            "short": {
+                "en": "Prayer of Manasses"
+            },
+            "long": {
+                "en": "The Prayer of Manasses King of Judah when He was Held Captive in Babylon"
+            }
+        },
+        "book-ps2": {
+            "abbr": {
+                "en": "Ps151"
+            },
+            "short": {
+                "en": "Psalm 151"
+            },
+            "long": {
+                "en": "Psalm 151"
+            }
+        },
+        "book-dag": {
+            "abbr": {
+                "en": "DanielG"
+            },
+            "short": {
+                "en": "Daniel (Greek)"
+            },
+            "long": {
+                "en": "The Book of Daniel with Greek Portions"
+            }
+        },
+        "section-jhn": {
+            "abbr": {
+                "en": "⠠⠚⠕⠓⠝"
+            },
+            "short": {
+                "en": "John"
+            },
+            "long": {
+                "en": "The Good News According to John"
+            }
+        },
+        "section-jhn_1": {
+            "abbr": {
+                "en": "⠠⠚⠕⠓⠝ ⠼⠁"
+            },
+            "short": {
+                "en": "John 1"
+            },
+            "long": {
+                "en": "The Good News According to John Chapters 1"
+            }
+        },
+        "section-jhn_1-1": {
+            "abbr": {
+                "en": "⠠⠚⠕⠓⠝ ⠼⠁⠤⠼⠁"
+            },
+            "short": {
+                "en": "John 1-1"
+            },
+            "long": {
+                "en": "The Good News According to John Chapters 1-1"
+            }
+        },
+        "section-jhn_2-2": {
+            "abbr": {
+                "en": "⠠⠚⠕⠓⠝ ⠼⠃⠤⠼⠃"
+            },
+            "short": {
+                "en": "John 2-2"
+            },
+            "long": {
+                "en": "The Good News According to John Chapters 2-2"
+            }
+        }
+    },
+    "ingredients": {
+        "processing_resources/styles/stylesheet.xml": {
+            "checksum": {
+                "md5": "5e94b21782928836d83e5af9b271a125"
+            },
+            "mimeType": "text/xml",
+            "size": 13900
+        },
+        "source/BBM/JHN_1-1.bbm": {
+            "checksum": {
+                "md5": "7a4d35451e31dc9fb8a553e08ea8fa92"
+            },
+            "mimeType": "text/xml",
+            "size": 33906
+        },
+        "release/PEF/JHN_1-1.pef": {
+            "checksum": {
+                "md5": "f00a9ed7f2aa146e2ff6a50cb12fa820"
+            },
+            "mimeType": "text/xml",
+            "size": 21261,
+            "scope": {
+                "JHN": [
+                    "1-1"
+                ]
+            }
+        }
+    },
+    "recipeSpecs": [
+        {
+            "variantId": "bp1",
+            "processor": "https://thedigitalbiblelibrary.org/barjo/0.1"
+        }
+    ],
+    "copyright": {
+        "fullStatementRich": {
+            "en": "<p><strong>PUBLIC DOMAIN</strong>. \"World English Bible\" is  trademark of <a href=\"https://eBible.org\">eBible.org</a>.</p>"
+        }
+    }
+}

--- a/docs/examples/artifacts/minimalTemplate.json
+++ b/docs/examples/artifacts/minimalTemplate.json
@@ -1,0 +1,11 @@
+{
+    "meta": {
+        "version": "0.2.0",
+        "variant": "template",
+        "templateName": {
+            "en": "A Minimal and Frankly Pointless Template"
+        },
+        "defaultLanguage": "en",
+        "dateCreated": "2018-02-15T22:33:50.875547+00:00"
+    }
+}

--- a/docs/examples/artifacts/textTranslation.json
+++ b/docs/examples/artifacts/textTranslation.json
@@ -9,6 +9,7 @@
     },
     "defaultLanguage": "en",
     "dateCreated": "2018-02-15T22:33:50.875547+00:00",
+    "normalization": "NFC",  
     "comments": ["Testing dblChanges.txt"]
   },
   "idServers": {

--- a/docs/examples/artifacts/textTranslation_derived.json
+++ b/docs/examples/artifacts/textTranslation_derived.json
@@ -167,8 +167,13 @@
       "checksum": {
         "md5": "0123456789abcdef0123456789abcdef"
       },
-      "mimeType": "text/x-usx+xml",
-      "role": "intot",
+        "mimeType": "text/x-usx+xml",
+        "scope": {
+            "GEN": [],
+            "EXO": [],
+            "LEV": []
+        },  
+      "role": "introduction",
       "size": 1234
     },
     "release/text/USX_1/GEN.usx": {
@@ -205,16 +210,22 @@
       "checksum": {
         "md5": "0123456789abcdef0123456789abcdef"
       },
-      "mimeType": "text/x-usx+xml",
-      "role": "intnt",
+        "mimeType": "text/x-usx+xml",
+        "scope": {
+            "MAT": []
+        },
+      "role": "introduction",
       "size": 1234
     },
     "release/text/USX_1/INTMAT.usx": {
       "checksum": {
         "md5": "0123456789abcdef0123456789abcdef"
       },
-      "mimeType": "text/x-usx+xml",
-      "role": "intMAT",
+        "mimeType": "text/x-usx+xml",
+        "scope": {
+            "MAT": ["1"]
+        },
+      "role": "introduction",
       "size": 1234
     },
     "release/text/USX_1/MAT.usx": {

--- a/docs/examples/artifacts/typesetScripture.json
+++ b/docs/examples/artifacts/typesetScripture.json
@@ -133,21 +133,24 @@
         "md5": "ea6cf3aaab5e87d4844a839f55712a2b"
       },
       "mimeType": "application/pdf",
-      "size": 21742731
+        "size": 21742731,
+        "role": "body"
     },
     "release/Cover.pdf": {
       "checksum": {
         "md5": "4f885b5395c57b623982fe1db37efbb1"
       },
       "mimeType": "application/pdf",
-      "size": 69141
+        "size": 69141,
+        "role": "cover"
     },
     "release/FrontCover.jpg": {
       "checksum": {
         "md5": "92b271f5d83ad1cc574276dd1d898854"
       },
-      "mimeType": "text/plain",
-      "size": 15323
+      "mimeType": "image/jpeg",
+        "size": 15323,
+        "role": "cover"
     },
     "source/zzzPADBL_2018POD_Source.zip": {
       "checksum": {

--- a/docs/examples/artifacts/xScripture.json
+++ b/docs/examples/artifacts/xScripture.json
@@ -38,7 +38,8 @@
     "flavorType": {
       "name": "scripture",
       "flavor": {
-        "name": "x-scriptureFingerPainting"
+          "name": "x-scriptureFingerPainting",
+          "foo": "baa"
       },
       "canonType": ["ot", "nt"],
       "canonSpec": {

--- a/schema/derived_meta.schema.json
+++ b/schema/derived_meta.schema.json
@@ -27,6 +27,9 @@
         "defaultLanguage": {
             "$ref": "meta_default_language.schema.json"
         },
+        "normalization": {
+            "$ref": "normalization.schema.json"
+        },
         "comments": {
             "$ref": "meta_comments.schema.json"
         }

--- a/schema/index.js
+++ b/schema/index.js
@@ -53,6 +53,8 @@ module.exports = {
         require("./source_metadata.schema.json"),
         require("./target_areas.schema.json"),
         require("./target_area.schema.json"),
+        require("./template_meta.schema.json"),
+        require("./template_metadata.schema.json"),
         require("./type.schema.json"),
         require("./unm49.schema.json"),
         require("./x_flavor.schema.json")

--- a/schema/index.js
+++ b/schema/index.js
@@ -45,6 +45,7 @@ module.exports = {
         require("./scripture/sign_language_video_translation.schema.json"),
         require("./scripture/text_translation.schema.json"),
         require("./scripture/typeset_scripture.schema.json"),
+        require("./role.schema.json"),
         require("./scope.schema.json"),
         require("./software_and_user_info.schema.json"),
         require("./source_meta.schema.json"),

--- a/schema/index.js
+++ b/schema/index.js
@@ -29,6 +29,7 @@ module.exports = {
         require("./metadata.schema.json"),
         require("./name.schema.json"),
         require("./names.schema.json"),
+        require("./normalization.schema.json"),
         require("./numbering_system.schema.json"),
         require("./parascriptural/word_alignment.schema.json"),
         require("./peripheral/versification.schema.json"),

--- a/schema/ingredient.schema.json
+++ b/schema/ingredient.schema.json
@@ -37,50 +37,7 @@
             "$ref": "scope.schema.json"
         },
         "role": {
-            "type": "string",
-            "anyOf": [
-                {
-                    "description": "A peripheral name, derived from the USFM 3 specification, eg \"maps\"",
-                    "enum": [
-                        "abbreviations",
-                        "alphacontents",
-                        "chron",
-                        "cnc",
-                        "contents",
-                        "cover",
-                        "foreword",
-                        "glo",
-                        "halftitle",
-                        "imprimatur",
-                        "lxxquotes",
-                        "maps",
-                        "measures",
-                        "ndx",
-                        "preface",
-                        "promo",
-                        "pubdata",
-                        "spine",
-                        "tdx",
-                        "title"
-                    ]
-                },
-                {
-                    "pattern": "^int(bible|dc|epistles|gospels|hist|nt|ot|pent|poetry|prophecy)$"
-                },
-                {
-                    "description": "int<bookCode>, eg \"intMAT\", to denote the introduction to a book.",
-                    "pattern": "^int(GEN|EXO|LEV|NUM|DEU|JOS|JDG|RUT|1SA|2SA|1KI|2KI|1CH|2CH|EZR|NEH|EST|JOB|PSA|PRO|ECC|SNG|ISA|JER|LAM|EZK|DAN|HOS|JOL|AMO|OBA|JON|MIC|NAM|HAB|ZEP|HAG|ZEC|MAL|MAT|MRK|LUK|JHN|ACT|ROM|1CO|2CO|GAL|EPH|PHP|COL|1TH|2TH|1TI|2TI|TIT|PHM|HEB|JAS|1PE|2PE|1JN|2JN|3JN|JUD|REV|TOB|JDT|ESG|WIS|SIR|BAR|LJE|S3Y|SUS|BEL|1MA|2MA|3MA|4MA|1ES|2ES|MAN|PS2|ODA|PSS|JSA|JDB|TBS|SST|DNT|BLT|EZA|5EZ|6EZ|DAG|PS3|2BA|LBA|JUB|ENO|1MQ|2MQ|3MQ|REP|4BA|LAO)$"
-                },
-                {
-                    "enum": ["printBody", "printCover", "printThumbnail", "printFlowable"]
-                },
-                {
-                    "enum": ["timing", "credits"]
-                },
-                {
-                    "pattern": "^(name|sign|concept|place)(\\s.*\\S)?$"
-                }
-            ]
+            "$ref": "role.schema.json"
         }
     },
     "required": ["size", "mimeType"],

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -4,12 +4,34 @@
     "title": "Scripture Burrito Metadata",
     "type": "object",
     "description": "Scripture Burrito root metadata object.",
-    "oneOf": [
-        {
-            "$ref": "source_metadata.schema.json"
-        },
-        {
-            "$ref": "derived_metadata.schema.json"
+    "properties": {
+        "meta": {
+            "type": "object",
+            "properties": {
+                "variant": {
+                    "type": "string",
+                    "pattern": "^(source|derived)(_[A-Za-z][A-Za-z0-9]*)?$"
+                }
+            }
         }
-    ]
+    },
+    "if": {
+        "properties": {
+            "meta": {
+                "type": "object",
+                "properties": {
+                    "variant": {
+                        "type": "string",
+                        "pattern": "^source"
+                    }
+                }
+            }
+        }
+    },
+    "then": {
+        "$ref": "source_metadata.schema.json"
+    },
+    "else": {
+        "$ref": "derived_metadata.schema.json"
+    }
 }

--- a/schema/metadata.schema.json
+++ b/schema/metadata.schema.json
@@ -10,7 +10,7 @@
             "properties": {
                 "variant": {
                     "type": "string",
-                    "pattern": "^(source|derived)(_[A-Za-z][A-Za-z0-9]*)?$"
+                    "pattern": "^(source|derived|template)"
                 }
             }
         }
@@ -18,10 +18,8 @@
     "if": {
         "properties": {
             "meta": {
-                "type": "object",
                 "properties": {
                     "variant": {
-                        "type": "string",
                         "pattern": "^source"
                     }
                 }
@@ -32,6 +30,22 @@
         "$ref": "source_metadata.schema.json"
     },
     "else": {
-        "$ref": "derived_metadata.schema.json"
+        "if": {
+            "properties": {
+                "meta": {
+                    "properties": {
+                        "variant": {
+                            "pattern": "^derived"
+                        }
+                    }
+                }
+            }
+        },
+        "then": {
+            "$ref": "derived_metadata.schema.json"
+        },
+        "else": {
+            "$ref": "template_metadata.schema.json"
+        }
     }
 }

--- a/schema/normalization.schema.json
+++ b/schema/normalization.schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://burrito.bible/schema/normalization.schema.json",
+    "title": "Scripture Burrito Normalization",
+    "type": "string",
+    "description": "Unicode Normalization Options.",
+    "enum": [
+        "NFC",
+        "NFD",
+        "NFKC",
+        "NFKD"
+    ]
+}

--- a/schema/recipe_specs.schema.json
+++ b/schema/recipe_specs.schema.json
@@ -7,10 +7,16 @@
     "items": {
         "type": "object",
         "properties": {
-            "id": {
+            "variantId": {
                 "$ref": "common.schema.json#/definitions/trimmedText"
             },
-            "href": {
+            "processor": {
+                "$ref": "common.schema.json#/definitions/url"
+            },
+            "algorithmFormat": {
+                "$ref": "common.schema.json#/definitions/url"
+            },
+            "algorithm": {
                 "oneOf": [
                     {
                         "$ref": "common.schema.json#/definitions/path"
@@ -20,11 +26,11 @@
                     }
                 ]
             },
-            "metadata": {
-                "type": "object"
+            "data": {
+                "$ref": "common.schema.json#/definitions/path"
             }
         },
-        "required": ["id"],
+        "required": ["variantId", "processor"],
         "additionalProperties": false
     }
 }

--- a/schema/role.schema.json
+++ b/schema/role.schema.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://burrito.bible/schema/role.schema.json",
+    "title": "Scripture Burrito Role",
+    "type": "string",
+    "description": "Roles which may be optionally attached to an ingredient.",
+    "oneOf": [
+        {
+            "description": "A USX peripheral label,eg \"maps\"",
+            "enum": [
+                "abbreviations",
+                "alphacontents",
+                "chron",
+                "cnc",
+                "contents",
+                "cover",
+                "foreword",
+                "glo",
+                "halftitle",
+                "imprimatur",
+                "lxxquotes",
+                "maps",
+                "measures",
+                "ndx",
+                "preface",
+                "promo",
+                "pubdata",
+                "spine",
+                "tdx",
+                "title"
+            ]
+        },
+        {
+            "description": "A role for story-based or video works, eg \"teaching\"",
+            "enum": [
+                "background",
+                "bridge",
+                "credits",
+                "diagram",
+                "gloss",
+                "illustration",
+                "introduction",
+                "scripture",
+                "teaching",
+                "timing"
+            ]
+        },
+        {
+            "description": "A label for story-type units",
+            "pattern": "^unit\\s.*\\S$"
+        },
+        {
+            "description": "A label for dictionary-type resources",
+            "pattern": "^(name|sign|word|concept|place)(\\s.*\\S)?$"
+        },
+        {
+            "description": "A role for PoD-type content, eg \"printCover\"",
+            "enum": ["body", "thumbnail"]
+        },
+        {
+            "description": "An x-role",
+            "pattern": "^x-\\S.*\\S$"
+        }
+    ]
+}

--- a/schema/role.schema.json
+++ b/schema/role.schema.json
@@ -46,16 +46,16 @@
             ]
         },
         {
+            "description": "A role for PoD-type content, eg \"printCover\"",
+            "enum": ["body", "thumbnail"]
+        },
+        {
             "description": "A label for story-type units",
             "pattern": "^unit\\s.*\\S$"
         },
         {
             "description": "A label for dictionary-type resources",
             "pattern": "^(name|sign|word|concept|place)(\\s.*\\S)?$"
-        },
-        {
-            "description": "A role for PoD-type content, eg \"printCover\"",
-            "enum": ["body", "thumbnail"]
         },
         {
             "description": "An x-role",

--- a/schema/scripture/audio_translation.schema.json
+++ b/schema/scripture/audio_translation.schema.json
@@ -29,9 +29,44 @@
         "name": {
             "const": "audioTranslation"
         },
-        "dramatization": {
-            "type": "string",
-            "enum": ["dramatized", "nonDramatized", "singleVoice"]
+        "performance": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": ["singleVoice", "multipleVoice", "reading", "drama", "withMusic", "withEffects", "withHeadings"]
+            },
+            "uniqueItems": true,
+            "additionalItems": false,
+            "allOf": [
+                {
+                    "if": {
+                        "contains": {
+                            "const": "singleVoice"
+                        }
+                    },
+                    "then": {
+                        "not": {
+                            "contains": {
+                                "const": "multipleVoice"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "contains": {
+                            "const": "reading"
+                        }
+                    },
+                    "then": {
+                        "not": {
+                            "contains": {
+                                "const": "drama"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "formats": {
             "type": "object",
@@ -56,6 +91,6 @@
             }
         }
     },
-    "required": ["dramatization", "formats"],
+    "required": ["performance", "formats"],
     "additionalProperties": false
 }

--- a/schema/scripture/audio_translation.schema.json
+++ b/schema/scripture/audio_translation.schema.json
@@ -50,6 +50,11 @@
                                 "const": "multipleVoice"
                             }
                         }
+                    },
+                    "else": {
+                        "contains": {
+                            "const": "multipleVoice"
+                        }
                     }
                 },
                 {
@@ -63,6 +68,11 @@
                             "contains": {
                                 "const": "drama"
                             }
+                        }
+                    },
+                    "else": {
+                        "contains": {
+                            "const": "drama"
                         }
                     }
                 }

--- a/schema/source_meta.schema.json
+++ b/schema/source_meta.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "variant": {
             "type": "string",
-            "const": "source",
+            "pattern": "^source(_[A-Za-z][A-Za-z0-9]*)?$",
             "description": "The type of variant represented in the burrito (which must be source which we pretend is not a variant even though it kinda is really)."
         },
         "dateCreated": {
@@ -26,6 +26,9 @@
         },
         "defaultLanguage": {
             "$ref": "meta_default_language.schema.json"
+        },
+        "normalization": {
+            "$ref": "normalization.schema.json"
         },
         "comments": {
             "$ref": "meta_comments.schema.json"

--- a/schema/template_meta.schema.json
+++ b/schema/template_meta.schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://burrito.bible/schema/template_meta.schema.json",
+    "title": "Scripture Burrito Meta (Template)",
+    "type": "object",
+    "description": "Information about the Scripture Burrito metadata file.",
+    "properties": {
+        "variant": {
+            "type": "string",
+            "const": "template",
+            "description": "A template is a template"
+        },
+        "templateName": {
+            "$ref": "common.schema.json#/definitions/localizedText"
+        },
+        "dateCreated": {
+            "$ref": "meta_date_created.schema.json"
+        },
+        "version": {
+            "$ref": "meta_version.schema.json"
+        },
+        "generator": {
+            "$ref": "software_and_user_info.schema.json",
+            "description": "Information about the program and user who generated this burrito."
+        },
+        "uploader": {
+            "$ref": "software_and_user_info.schema.json",
+            "description": "Information about the program and user who uploaded this burrito."
+        },
+        "defaultLanguage": {
+            "$ref": "meta_default_language.schema.json"
+        },
+        "normalization": {
+            "$ref": "normalization.schema.json"
+        },
+        "comments": {
+            "$ref": "meta_comments.schema.json"
+        }
+    },
+    "required": ["version", "variant", "defaultLanguage", "dateCreated", "templateName"],
+    "additionalProperties": false
+}

--- a/schema/template_metadata.schema.json
+++ b/schema/template_metadata.schema.json
@@ -35,9 +35,6 @@
         "copyright": {
             "noRef": "copyright.schema.json"
         },
-        "promotion": {
-            "noRef": "promotion.schema.json"
-        },
         "ingredients": {
             "noRef": "ingredients.schema.json"
         },

--- a/schema/template_metadata.schema.json
+++ b/schema/template_metadata.schema.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://burrito.bible/schema/template_metadata.schema.json",
+    "title": "Scripture Burrito Metadata (Template)",
+    "type": "object",
+    "description": "Scripture Burrito Template root.",
+    "properties": {
+        "meta": {
+            "$ref": "template_meta.schema.json"
+        },
+        "idServers": {
+            "noRef": "id_servers.schema.json"
+        },
+        "identification": {
+            "noRef": "identification.schema.json"
+        },
+        "confidentiality": {
+            "noRef": "confidentiality.schema.json"
+        },
+        "type": {
+            "noRef": "type.schema.json"
+        },
+        "relationships": {
+            "noRef": "relationships.schema.json"
+        },
+        "languages": {
+            "noRef": "languages.schema.json"
+        },
+        "targetAreas": {
+            "noRef": "target_areas.schema.json"
+        },
+        "agencies": {
+            "noRef": "agencies.schema.json"
+        },
+        "copyright": {
+            "noRef": "copyright.schema.json"
+        },
+        "promotion": {
+            "noRef": "promotion.schema.json"
+        },
+        "ingredients": {
+            "noRef": "ingredients.schema.json"
+        },
+        "names": {
+            "noRef": "names.schema.json"
+        },
+        "recipeSpecs": {
+            "noRef": "recipe.schema.json"
+        }
+    },
+    "required": ["meta"],
+    "additionalProperties": false
+}

--- a/schema/type.schema.json
+++ b/schema/type.schema.json
@@ -5,55 +5,94 @@
     "title": "Type",
     "type": "object",
     "description": "Contains properties describing the burrito flavor type.",
-    "oneOf": [
-        {
+    "properties": {
+        "flavorType": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "enum": [
+                        "scripture",
+                        "gloss",
+                        "parascriptural",
+                        "peripheral"
+                    ]
+                }
+            }
+        }
+    },
+    "if" : {
+        "properties": {
+            "flavorType": {
+                "properties": {
+                    "name": {
+                        "const": "scripture"
+                    }
+                }
+            }
+        }
+    },
+    "then":
+    {
+        "properties": {
+            "flavorType": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "const": "scripture"
+                    },
+                    "flavor": {
+                        "type": "object",
+                        "oneOf": [
+                            {
+                                "$ref": "scripture/text_translation.schema.json"
+                            },
+                            {
+                                "$ref": "scripture/audio_translation.schema.json"
+                            },
+                            {
+                                "$ref": "scripture/typeset_scripture.schema.json"
+                            },
+                            {
+                                "$ref": "scripture/embossed_braille_scripture.schema.json"
+                            },
+                            {
+                                "$ref": "scripture/sign_language_video_translation.schema.json"
+                            },
+                            {
+                                "$ref": "x_flavor.schema.json"
+                            }
+                        ]
+                    },
+                    "currentScope": {
+                        "$ref": "scope.schema.json"
+                    },
+                    "canonType": {
+                        "$ref": "canon_type.schema.json"
+                    },
+                    "canonSpec": {
+                        "$ref": "canon_spec.schema.json"
+                    }
+                },
+                "required": ["name", "flavor", "currentScope", "canonType", "canonSpec"],
+                "additionalProperties": false
+            }
+        }
+    },
+    "else": {
+        "if" : {
             "properties": {
                 "flavorType": {
-                    "type": "object",
                     "properties": {
                         "name": {
-                            "type": "string",
-                            "const": "scripture"
-                        },
-                        "flavor": {
-                            "type": "object",
-                            "oneOf": [
-                                {
-                                    "$ref": "scripture/text_translation.schema.json"
-                                },
-                                {
-                                    "$ref": "scripture/audio_translation.schema.json"
-                                },
-                                {
-                                    "$ref": "scripture/typeset_scripture.schema.json"
-                                },
-                                {
-                                    "$ref": "scripture/embossed_braille_scripture.schema.json"
-                                },
-                                {
-                                    "$ref": "scripture/sign_language_video_translation.schema.json"
-                                },
-                                {
-                                    "$ref": "x_flavor.schema.json"
-                                }
-                            ]
-                        },
-                        "currentScope": {
-                            "$ref": "scope.schema.json"
-                        },
-                        "canonType": {
-                            "$ref": "canon_type.schema.json"
-                        },
-                        "canonSpec": {
-                            "$ref": "canon_spec.schema.json"
+                            "const": "gloss"
                         }
-                    },
-                    "required": ["name", "flavor", "currentScope", "canonType", "canonSpec"],
-                    "additionalProperties": false
+                    }
                 }
             }
         },
-        {
+        "then": {
             "properties": {
                 "flavorType": {
                     "type": "object",
@@ -88,77 +127,90 @@
                 }
             }
         },
-        {
-            "properties": {
-                "flavorType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "const": "parascriptural"
-                        },
-                        "flavor": {
-                            "type": "object",
-                            "oneOf": [
-                                {
-                                    "$ref": "parascriptural/word_alignment.schema.json"
-                                },
-                                {
-                                    "$ref": "x_flavor.schema.json"
-                                }
-                            ]
-                        },
-                        "currentScope": {
-                            "$ref": "scope.schema.json"
-                        },
-                        "canonType": {
-                            "$ref": "canon_type.schema.json"
-                        },
-                        "canonSpec": {
-                            "$ref": "canon_spec.schema.json"
+        "else": {
+            "if" : {
+                "properties": {
+                    "flavorType": {
+                        "properties": {
+                            "name": {
+                                "const": "parascriptural"
+                            }
                         }
-                    },
-                    "required": ["name", "flavor"],
-                    "additionalProperties": false
+                    }
                 }
-            }
-        },
-        {
-            "properties": {
-                "flavorType": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "const": "peripheral"
+            },
+            "then": {
+                "properties": {
+                    "flavorType": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "parascriptural"
+                            },
+                            "flavor": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "$ref": "parascriptural/word_alignment.schema.json"
+                                    },
+                                    {
+                                        "$ref": "x_flavor.schema.json"
+                                    }
+                                ]
+                            },
+                            "currentScope": {
+                                "$ref": "scope.schema.json"
+                            },
+                            "canonType": {
+                                "$ref": "canon_type.schema.json"
+                            },
+                            "canonSpec": {
+                                "$ref": "canon_spec.schema.json"
+                            }
                         },
-                        "flavor": {
-                            "type": "object",
-                            "oneOf": [
-                                {
-                                    "$ref": "peripheral/versification.schema.json"
-                                },
-                                {
-                                    "$ref": "x_flavor.schema.json"
-                                }
-                            ]
+                        "required": ["name", "flavor"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "else": {
+                "properties": {
+                    "flavorType": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "peripheral"
+                            },
+                            "flavor": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "$ref": "peripheral/versification.schema.json"
+                                    },
+                                    {
+                                        "$ref": "x_flavor.schema.json"
+                                    }
+                                ]
+                            },
+                            "currentScope": {
+                                "$ref": "scope.schema.json"
+                            },
+                            "canonType": {
+                                "$ref": "canon_type.schema.json"
+                            },
+                            "canonSpec": {
+                                "$ref": "canon_spec.schema.json"
+                            }
                         },
-                        "currentScope": {
-                            "$ref": "scope.schema.json"
-                        },
-                        "canonType": {
-                            "$ref": "canon_type.schema.json"
-                        },
-                        "canonSpec": {
-                            "$ref": "canon_spec.schema.json"
-                        }
-                    },
-                    "required": ["name", "flavor"],
-                    "additionalProperties": false
+                        "required": ["name", "flavor"],
+                        "additionalProperties": false
+                    }
                 }
             }
         }
-    ],
+    },
     "allOf": [
         {
             "$ref": "canon_constraints.schema.json#/definitions/OTConstraint"

--- a/schema/type.schema.json
+++ b/schema/type.schema.json
@@ -10,7 +10,6 @@
             "type": "object",
             "properties": {
                 "name": {
-                    "type": "string",
                     "enum": [
                         "scripture",
                         "gloss",
@@ -32,8 +31,7 @@
             }
         }
     },
-    "then":
-    {
+    "then": {
         "properties": {
             "flavorType": {
                 "type": "object",
@@ -44,26 +42,25 @@
                     },
                     "flavor": {
                         "type": "object",
-                        "oneOf": [
-                            {
-                                "$ref": "scripture/text_translation.schema.json"
-                            },
-                            {
-                                "$ref": "scripture/audio_translation.schema.json"
-                            },
-                            {
-                                "$ref": "scripture/typeset_scripture.schema.json"
-                            },
-                            {
-                                "$ref": "scripture/embossed_braille_scripture.schema.json"
-                            },
-                            {
-                                "$ref": "scripture/sign_language_video_translation.schema.json"
-                            },
-                            {
-                                "$ref": "x_flavor.schema.json"
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "oneOf": [
+                                    {
+                                        "enum": [
+                                            "textTranslation",
+                                            "audioTranslation",
+                                            "typesetScripture",
+                                            "embossedBrailleScripture",
+                                            "signLanguageVideoTranslation"
+                                        ]
+                                    },
+                                    {
+                                        "pattern": "^x-"
+                                    }
+                                ]
                             }
-                        ]
+                        }
                     },
                     "currentScope": {
                         "$ref": "scope.schema.json"
@@ -75,8 +72,159 @@
                         "$ref": "canon_spec.schema.json"
                     }
                 },
-                "required": ["name", "flavor", "currentScope", "canonType", "canonSpec"],
+                "required": ["flavor", "currentScope", "canonType", "canonSpec"],
                 "additionalProperties": false
+            }
+        },
+        "required": ["flavorType"],
+        "if": {
+            "properties": {
+                "flavorType" : {
+                    "properties": {
+                        "flavor": {
+                            "properties": {
+                                "name": {
+                                    "const": "textTranslation"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "then": 
+        {
+            "properties": {
+                "flavorType" : {
+                    "properties": {
+                        "flavor" : {
+                            "$ref": "scripture/text_translation.schema.json"
+                        }
+                    }
+                }
+            }
+        },
+        "else": {
+            "if": {
+                "properties": {
+                    "flavorType" : {
+                        "properties": {
+                            "flavor": {
+                                "properties": {
+                                    "name": {
+                                        "const": "audioTranslation"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "flavorType" : {
+                        "properties": {
+                            "flavor" : {
+                                "$ref": "scripture/audio_translation.schema.json"
+                            }
+                        }
+                    }
+                }
+            },
+            "else": {
+                "if": {
+                    "properties": {
+                        "flavorType" : {
+                            "properties": {
+                                "flavor": {
+                                    "properties": {
+                                        "name": {
+                                            "const": "typesetScripture"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "then": {
+                    "properties": {
+                        "flavorType" : {
+                            "properties": {
+                                "flavor" : {
+                                    "$ref": "scripture/typeset_scripture.schema.json"
+                                }
+                            }
+                        }
+                    }
+                },
+                "else": {
+                    "if": {
+                        "properties": {
+                            "flavorType" : {
+                                "properties": {
+                                    "flavor": {
+                                        "properties": {
+                                            "name": {
+                                                "const": "embossedBrailleScripture"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "flavorType" : {
+                                "properties": {
+                                    "flavor" : {
+                                        "$ref": "scripture/embossed_braille_scripture.schema.json"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "else": {
+                        "if": {
+                            "properties": {
+                                "flavorType" : {
+                                    "properties": {
+                                        "flavor": {
+                                            "properties": {
+                                                "name": {
+                                                    "const": "signLanguageVideoTranslation"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "flavorType" : {
+                                    "properties": {
+                                        "flavor" : {
+                                            "$ref": "scripture/sign_language_video_translation.schema.json"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "else": {
+                            "properties": {
+                                "flavorType" : {
+                                    "properties": {
+                                        "flavor" : {
+                                            "$ref": "x_flavor.schema.json"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
This PR aims to complete the immediate, outstanding 0.2 issues.

# Roles

In last week's episode, we made roles and scope independent, so that an ingredient can have either, both or neither. In this PR I've reworked the roles to make sense alongside scope, eg
```
    "release/text/USX_1/OTINT.usx": {
      "checksum": {
        "md5": "0123456789abcdef0123456789abcdef"
      },
        "mimeType": "text/x-usx+xml",
        "scope": {
            "GEN": [],
            "EXO": [],
            "LEV": [],
...
        },
      "role": "introduction",
      "size": 1234
    }
```

We still have the full list USX peripherals (including values that make no sense without knowledge of Paratext internals):
```
                "abbreviations",
                "alphacontents",
                "chron",
                "cnc",
                "contents",
                "cover",
                "foreword",
                "glo",
                "halftitle",
                "imprimatur",
                "lxxquotes",
                "maps",
                "measures",
                "ndx",
                "preface",
                "promo",
                "pubdata",
                "spine",
                "tdx",
                "title"
```

I expanded the list of audiovisual-oriented values to cover everything I've seen in CBT translations:
```
                "background",
                "bridge",
                "credits",
                "diagram",
                "gloss",
                "illustration",
                "introduction",
                "scripture",
                "teaching",
                "timing"
```
I made the list of PoD-oriented roles shorter by reusing values from other lists:
```
                "body",
                "thumbnail"
```
There are also regex patterns for systems where resources are intended to be indexed (eg SL word definition videos):
```
^(name|sign|word|concept|place)(\\s.*\\S)?$
```
I added a regex pattern for labelling story-like units in CBT:
```
^unit\\s.*\\S$
```
and - in the expectation that this list will grow, I added x-roles:
```
^x-\\S.*\\S$
```
# Normalization
This is now an optional field in the meta section:
```
"normalization": "NFC"
```
# Less oneOf
I reworked the schema at three levels to replace oneOf constructs with enums of a key plus conditional subschemas. The main benefit of this is shorter and more readable error messages. (It may make things faster too.)
# Template metadata subschema
While I was reworking the top-level schema I added a "template" option. Right now it's extremely lax, but at least it exists.
# Enums for audio
I replaced the tristate dramatization field with an array of tags:
```
"performance": ["multipleVoice", "drama", "withMusic"]
```
The array must contain:
- exactly one of "singleVoice" or "multipleVoice"
- exactly one of "reading or "drama"

Other permitted values are
```
"withMusic",
"withEffects",
"withHeadings"
```
# Braille Example Document
I thought I copied this over last time, but apparently I didn't. It's definitely here this time.

***

I think all the example docs validate. I haven't prettyprinted since I realised, after starting to edit, that the files still have inconsistent indents, and fixing that in the PR would hide all the interesting changes.