### PR TITLE
Use semver regex

### DIFF
--- a/schema/meta_version.schema.json
+++ b/schema/meta_version.schema.json
@@ -4,6 +4,6 @@
     "$$target": "meta_version.schema.json",
     "title": "Meta Version",
     "type": "string",
-    "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+    "enum": ["0.2.0-beta"],
     "description": "Version of the Scripture Burrito specification this file follows."
 }

--- a/schema/meta_version.schema.json
+++ b/schema/meta_version.schema.json
@@ -4,6 +4,6 @@
     "$$target": "meta_version.schema.json",
     "title": "Meta Version",
     "type": "string",
-    "pattern": "^[0-9]+(\\.[0-9]+)*$",
+    "pattern": "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
     "description": "Version of the Scripture Burrito specification this file follows."
 }


### PR DESCRIPTION
Our docs specify that we use semantic versioning so our regex should also support the full range of semver options. Regex copied from https://semver.org/.

In particular, the previous regex only allowed for numbers, which means that our current release, `0.2.0-beta`, is actually invalid!