### PR TITLE
Add npm support to scripture-burrito

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,25 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - master # Change this to your default branch
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      - name: Publish if version has been updated
+        uses: pascalgn/npm-publish-action@4f4bf159e299f65d21cd1cbd96fc5d53228036df
+        with: # All of theses inputs are optional
+          tag_name: "v%s"
+          tag_message: "v%s"
+          commit_pattern: "^Release (\\S+)"
+        env: # More info about the environment variables in the README
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-node_modules
 proto_doc/dbl_2_3/briefing_papers/DBLMetadata23.log
 proto_doc/dbl_2_3/briefing_papers/SB01RFC.log
+
+# build artifacts and language support
+node_modules
 **/_build
 **/build
-.DS_Store
+.python-version
 
 # IDE artifacts
 .vscode
@@ -16,3 +18,6 @@ docs/schema/metadata.rng
 *~
 \#*\#
 .\#*
+
+# Mac OSX artifacts
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,5 @@
 {
-  "name": "scripture-burrito",
-  "version": "0.2.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
-    }
-  }
+    "name": "scripture-burrito",
+    "version": "0.2.0",
+    "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,47 @@
 {
     "name": "scripture-burrito",
-    "version": "0.2.0",
-    "lockfileVersion": 1
+    "version": "0.2.0-beta.2",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "ajv": {
+            "version": "6.12.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+            "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,13 @@
 {
-  "requires": true,
+  "name": "scripture-burrito",
+  "version": "0.2.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "prettier": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
-      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
         "url": "git+https://github.com/bible-technology/scripture-burrito.git"
     },
     "keywords": [
-        "\"Scripture",
-        "Burrito\"",
-        "\"Burrito\"",
-        "\"SB\""
+        "Scripture",
+        "Burrito",
+        "Scripture-Burrito",
+        "SB"
     ],
     "author": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,31 +1,29 @@
 {
-  "name": "scripture-burrito",
-  "version": "0.2.0",
-  "description": "Schema support for Scripture Burrito",
-  "main": "schema/index.js",
-  "directories": {
-    "doc": "docs"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/bible-technology/scripture-burrito.git"
-  },
-  "keywords": [
-    "\"Scripture",
-    "Burrito\"",
-    "\"Burrito\"",
-    "\"SB\""
-  ],
-  "author": "",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/bible-technology/scripture-burrito/issues"
-  },
-  "homepage": "https://github.com/bible-technology/scripture-burrito#readme",
-  "dependencies": {
-    "prettier": "^2.0.5"
-  }
+    "name": "scripture-burrito",
+    "version": "0.2.0",
+    "description": "Schema support for Scripture Burrito",
+    "main": "schema/index.js",
+    "directories": {
+        "doc": "docs"
+    },
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bible-technology/scripture-burrito.git"
+    },
+    "keywords": [
+        "\"Scripture",
+        "Burrito\"",
+        "\"Burrito\"",
+        "\"SB\""
+    ],
+    "author": "",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/bible-technology/scripture-burrito/issues"
+    },
+    "homepage": "https://github.com/bible-technology/scripture-burrito#readme",
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,29 +1,32 @@
 {
-    "name": "scripture-burrito",
-    "version": "0.2.0",
-    "description": "Schema support for Scripture Burrito",
-    "main": "schema/index.js",
-    "directories": {
-        "doc": "docs"
-    },
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/bible-technology/scripture-burrito.git"
-    },
-    "keywords": [
-        "Scripture",
-        "Burrito",
-        "Scripture-Burrito",
-        "SB"
-    ],
-    "author": "",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/bible-technology/scripture-burrito/issues"
-    },
-    "homepage": "https://github.com/bible-technology/scripture-burrito#readme",
-    "dependencies": {}
+  "name": "scripture-burrito",
+  "version": "0.2.0-beta.2",
+  "description": "Schema support for Scripture Burrito",
+  "main": "schema/index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node code/validate.js metadata docs/examples/artifacts/*.json",
+    "validate": "node code/validate.js metadata"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bible-technology/scripture-burrito.git"
+  },
+  "keywords": [
+    "Scripture",
+    "Burrito",
+    "Scripture-Burrito",
+    "SB"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bible-technology/scripture-burrito/issues"
+  },
+  "homepage": "https://github.com/bible-technology/scripture-burrito#readme",
+  "dependencies": {
+    "ajv": "^6.12.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "scripture-burrito",
+  "version": "0.2.0",
+  "description": "Schema support for Scripture Burrito",
+  "main": "schema/index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bible-technology/scripture-burrito.git"
+  },
+  "keywords": [
+    "\"Scripture",
+    "Burrito\"",
+    "\"Burrito\"",
+    "\"SB\""
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/bible-technology/scripture-burrito/issues"
+  },
+  "homepage": "https://github.com/bible-technology/scripture-burrito#readme",
+  "dependencies": {
+    "prettier": "^2.0.5"
+  }
+}


### PR DESCRIPTION
So that I can add programmatic validation to the document sample repos that I'm creating, I'd like to be able to import the schema definition as a Node package from github (and, eventually, the npm repo). 

Adding package.json to the repo allows for installing via npm. 

I defined the license as MIT in package.json, we should probably discuss this in the next meeting.