### PR TITLE
bug fixes for  schema/scripture_flavor_type.schema.json

### DIFF
--- a/schema/scripture_flavor_type.schema.json
+++ b/schema/scripture_flavor_type.schema.json
@@ -22,10 +22,7 @@
                             "$ref": "scripture/audio_translation.schema.json"
                         },
                         {
-                            "$ref": "scripture/print_publication.schema.json"
-                        },
-                        {
-                            "$ref": "scripture/braille_scripture_publication.schema.json"
+                            "$ref": "scripture/typeset_scripture.schema.json"
                         },
                         {
                             "$ref": "scripture/sign_language_video_translation.schema.json"
@@ -36,8 +33,8 @@
                     ]
                 },
                 "bookScope": {
-                    "$ref": "book_scope.schema.json"
-                },
+                    "$ref": "scope.schema.json"
+                }
             },
             "required": ["name", "bookScope", "flavor"],
             "additionalProperties": false


### PR DESCRIPTION
Some of the files refered to were removed or renamed. These changes were not reflected in the consuming file (modified in this commit) and caused consuming tools to break. I assume these changes were originally intended to be reflected in this schema.  The relevant details from the git log of which files were changed are noted below:

Further, I've kept the key "bookScope" even though the filename is "scope.schema.json". I assume the file names used are semantic, however I did not want to break backwards compatibility. I am willing to make the change to update the schema from "bookScope" to "scope" if the semantics should be reflected between the schema definition and the names of the files used.

I've also removed the extraneous comma as noted in issue #310

Relevant Commit Logs:

commit 69e2f8a1d3ee29c149865baee991b48776154f73
Author: Mark Howe <mvahowe@gmail.com>
Date:   Thu Apr 2 17:26:29 2020 +0200
D       schema/scripture/braille_scripture_publication.schema.json
R097    schema/scripture/print_publication.schema.json
        schema/scripture/typeset_scripture.schema.json

commit 847f0eb2f0c8191165e38280d3c52558c3446e23
Author: Mark Howe <mvahowe@gmail.com>
Date:   Wed Feb 26 15:17:59 2020 +0000
R100    schema/book_scope.schema.json   schema/scope.schema.json