### PR TITLE
Fix schema registration, x- token pattern, and relationship constraints

### DIFF
--- a/docs/examples/artifacts/audioAlignment.json
+++ b/docs/examples/artifacts/audioAlignment.json
@@ -10,6 +10,14 @@
     "defaultLocale": "en",
     "dateCreated": "2025-11-10T08:00:00Z"
   },
+  "idAuthorities": {
+    "uw": {
+      "id": "https://www.unfoldingword.org",
+      "name": {
+        "en": "unfoldingWord"
+      }
+    }
+  },
   "identification": {
     "name": {
       "en": "Ephesians Audio–Text Alignment"

--- a/docs/examples/artifacts/audioTranslation.json
+++ b/docs/examples/artifacts/audioTranslation.json
@@ -11,6 +11,14 @@
     "defaultLocale": "dje",
     "dateCreated": "2025-11-10T14:00:00+01:00"
   },
+  "idAuthorities": {
+    "sc": {
+      "id": "https://seedcompany.com",
+      "name": {
+        "en": "Seed Company"
+      }
+    }
+  },
   "identification": {
     "name": {
       "en": "Zarma NT Audio — Titus",

--- a/schema/common.schema.json
+++ b/schema/common.schema.json
@@ -42,7 +42,7 @@
         },
         "xToken": {
             "type": "string",
-            "pattern": "^x-[a-z][A-za-z0-9]*$",
+            "pattern": "^x-[a-z][A-Za-z0-9]*$",
             "description": "User-defined token, prefixed with x-"
         },
         "idAuthorityLabel": {

--- a/schema/index.js
+++ b/schema/index.js
@@ -6,6 +6,7 @@ module.exports = {
     schemas: [
         require("./agencies.schema.json"),
         require("./agency.schema.json"),
+        require("./alignment/alignment.schema.json"),
         require("./common.schema.json"),
         require("./confidential.schema.json"),
         require("./copyright.schema.json"),

--- a/schema/relationship.schema.json
+++ b/schema/relationship.schema.json
@@ -22,7 +22,7 @@
                     ]
                 },
                 {
-                    "pattern": "^x-[a-z][A-za-z0-9]*$"
+                    "pattern": "^x-[a-z][A-Za-z0-9]*$"
                 }
             ],
             "minLength": 1
@@ -40,45 +40,5 @@
     },
     "required": ["relationType", "flavor", "id"],
     "additionalProperties": false,
-    "oneOf": [
-        {
-            "properties": {
-                "flavor": {
-                    "type": "string",
-                    "pattern": "^x-[a-z][A-za-z0-9]*$"
-                }
-            },
-            "$comment": "Custom flavors can be used with any relationType."
-        },
-        {
-            "properties": {
-                "relationType": {
-                    "const": "source"
-                },
-                "flavor": {
-                    "enum": ["textTranslation", "audioTranslation", "alignment"]
-                }
-            }
-        },
-        {
-            "properties": {
-                "relationType": {
-                    "const": "target"
-                },
-                "flavor": {}
-            }
-        },
-        {
-            "properties": {
-                "relationType": {
-                    "const": "expression"
-                },
-                "flavor": {
-                    "not": {
-                        "const": "scriptureText"
-                    }
-                }
-            }
-        }
-    ]
+    "$comment": "Any relationType may be combined with any standard or custom flavor, so the relationType and flavor enums above are the only constraints."
 }

--- a/schema/scripture/text_translation.schema.json
+++ b/schema/scripture/text_translation.schema.json
@@ -43,7 +43,7 @@
             },
             "propertyNames": {
                 "type": "string",
-                "pattern": "^(x-)?[a-z][A-za-z0-9]*$",
+                "pattern": "^(x-)?[a-z][A-Za-z0-9]*$",
                 "oneOf": [
                     { "$ref": "../common.schema.json#/definitions/xToken" },
                     { "enum": ["usxRefs", "usxDirs", "typesetAsVersedParagraphs"] }

--- a/schema/wrapper/wrapper_burrito.schema.json
+++ b/schema/wrapper/wrapper_burrito.schema.json
@@ -21,7 +21,7 @@
                     "enum": ["source", "derived", "supplemental"]
                 },
                 {
-                    "pattern": "^x-[a-z][A-za-z0-9]*$"
+                    "pattern": "^x-[a-z][A-Za-z0-9]*$"
                 }
             ],
             "description": "The role this burrito plays within the wrapper."


### PR DESCRIPTION
Addresses items 1, 2, 3, and 5 of #346.

**Item 3:** Both routes the issue offers assume the top-level `oneOf` carries constraints worth keeping. It doesn't: it rejects 8 of the 20 documented `relationType` × `flavor` combinations — including `target`/`expression` with any `x-` flavor, which its own `$comment` says must be allowed — and its only constraint not already in the `properties` enums excludes a flavor name, `scriptureText`, that has left the vocabulary. Deleting it leaves the enums as the sole constraint, exactly as `docs/flavors/derived_flavor.rst` specifies, and `textTranslation_derived.json` validates unchanged.

**Item 4:** Deferred pending a decision: whether `wrapper.json` should be dropped from the test glob, guarded in `metadata.schema.json`, or routed to the currently unregistered `wrapper/wrapper_metadata.schema.json`.

Remaining items (6+ from the issue comments) are deferred pending decisions recorded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Devin review: https://app.devin.ai/review/bible-technology/scripture-burrito/pull/363

Devin flags 2 unresolved bugs that are covered in the issue's pending-decision-items.
